### PR TITLE
Better way to determine next unused port

### DIFF
--- a/bin/create_port_map
+++ b/bin/create_port_map
@@ -7,6 +7,10 @@ unless (1..65535).cover?(port.to_i)
   raise 'a valid port number must be provided as the first argument'
 end
 
+if PortMap::Utilities.port_taken?(port.to_i)
+  raise 'port number is already taken'
+end
+
 server_conf = nil
 if File.exist?(PortMap::NginxConf::PORT_MAP_CONF_FILENAME)
   server_conf = PortMap::NginxConf.from_file(port, File.new(PortMap::NginxConf::PORT_MAP_CONF_FILENAME))

--- a/spec/port_map/utilities_spec.rb
+++ b/spec/port_map/utilities_spec.rb
@@ -70,57 +70,36 @@ RSpec.describe PortMap::Utilities do
       it 'returns STARTING_PORT_NUMBER' do
         expect(described_class.next_empty_port).to eq(described_class::STARTING_PORT_NUMBER)
       end
+
+      context 'next port taken by external process' do
+        it 'returns 1 port higher than the STARTING_PORT_NUMBER' do
+          allow(described_class).to receive(:port_taken?).and_return(true, false)
+          expect(described_class.next_empty_port).to eq(described_class::STARTING_PORT_NUMBER + 1)
+        end
+      end
     end
 
     context 'one port mapping exist' do
-      context 'with one location' do
-        let(:previous_highest_port_number) { 30000 }
-        let(:port_mappings) do
-          [
-            {
-              name: 'admin',
-              nginx_conf: '/usr/local/etc/nginx/servers/admin.port_map.conf',
-              server_name: 'admin.dev',
-              locations: [
-                {
-                  name: '/',
-                  proxy_pass: "http://127.0.0.1:#{previous_highest_port_number}"
-                }
-              ]
-            }
-          ]
-        end
-
-        it 'returns STARTING_PORT_NUMBER' do
-          expect(described_class.next_empty_port).to eq(previous_highest_port_number + described_class::PORT_NUMBER_INCREMENT)
-        end
+      let(:previous_highest_port_number) { 30000 }
+      let(:port_mappings) do
+        [
+          {
+            name: 'admin',
+            nginx_conf: '/usr/local/etc/nginx/servers/admin.port_map.conf',
+            server_name: 'admin.dev',
+            locations: [
+              {
+                name: '/',
+                proxy_pass: "http://127.0.0.1:#{previous_highest_port_number}"
+              }
+            ]
+          }
+        ]
       end
 
-      context 'with multiple locations' do
-        let(:previous_highest_port_number) { 30000 }
-        let(:port_mappings) do
-          [
-            {
-              name: 'admin',
-              nginx_conf: '/usr/local/etc/nginx/servers/admin.port_map.conf',
-              server_name: 'admin.dev',
-              locations: [
-                {
-                  name: '/',
-                  proxy_pass: "http://127.0.0.1:#{previous_highest_port_number}"
-                },
-                {
-                  name: '/test',
-                  proxy_pass: 'http://test.dev'
-                }
-              ]
-            }
-          ]
-        end
-
-        it 'returns STARTING_PORT_NUMBER' do
-          expect(described_class.next_empty_port).to eq(previous_highest_port_number + described_class::PORT_NUMBER_INCREMENT)
-        end
+      it 'returns 1 port higher than the highest' do
+        allow(described_class).to receive(:port_taken?).and_return(false)
+        expect(described_class.next_empty_port).to eq(previous_highest_port_number + 1)
       end
     end
 
@@ -135,7 +114,7 @@ RSpec.describe PortMap::Utilities do
             locations: [
               {
                 name: '/',
-                proxy_pass: 'http://127.0.0.1:20720'
+                proxy_pass: "http://127.0.0.1:#{previous_highest_port_number - 1}"
               }
             ]
           },
@@ -153,8 +132,9 @@ RSpec.describe PortMap::Utilities do
         ]
       end
 
-      it 'returns STARTING_PORT_NUMBER' do
-        expect(described_class.next_empty_port).to eq(previous_highest_port_number + described_class::PORT_NUMBER_INCREMENT)
+      it 'returns 1 port higher than the highest' do
+        allow(described_class).to receive(:port_taken?).and_return(false)
+        expect(described_class.next_empty_port).to eq(previous_highest_port_number + 1)
       end
     end
   end


### PR DESCRIPTION
Fixes #3

Improve the way we determine the next unused port by checking it using the `lsof` system command to see if any process is using the specified port.
