### PR TITLE
Fix the extra newlines being added to the /etc/hosts file

### DIFF
--- a/lib/port_map/hosts.rb
+++ b/lib/port_map/hosts.rb
@@ -21,7 +21,7 @@ module PortMap
     def self.contents
       File.readlines(HOSTS_FILENAME).reject do |line|
         line.strip.match(/#{PORT_MAP_TRACK_COMMENT}$/)
-      end.join
+      end.join.strip
     end
   end
 end


### PR DESCRIPTION
Fixes #2 

Extra newlines were being added to the /etc/hosts file when removing the placeholder line for port_map. Now we #strip the contents to remove excess newlines.
