### PR TITLE
Fix remove_port_map to account for proper order (.port_map.conf first)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ Installing this gem provides four executable commands:
 ### `port_map`
 - `port_map <command>`
   1. Adjusts/Adds a dynamic port number on command (assuming command takes `-p <number>` or `--port <number>`).
-  2. Executes `create_port_map <dynamic_port_number>`
-    1. Uses a `.port_map.conf` nginx server configuration (with a `$PORT` placeholder present), for generated nginx configuration.
-    2. Using a name specified in the `PORT_MAP_NAME` environment variable.
-    1. Using a name specified from the current directory.
+  2. Executes `create_port_map <dynamic_port_number>`, which goes through the following in order until a name can be determined).
+    1. Uses a `.port_map.conf` nginx server configuration (which has a server name and `$PORT` placeholder present), this then becomes the nginx configuration.
+    2. Using a name specified in the `PORT_MAP_NAME` environment variable, this name is then used to generate a nginx configuration.
+    3. Using a name specified from the current directory, this name is then used to generate a nginx configuration.
   3. Updates `/etc/hosts` with new entry `127.0.0.1 determined_name.dev #port_map`.
   4. Reloads nginx -- `sudo nginx -s reload`.
   5. Executes `<command>`.

--- a/bin/remove_port_map
+++ b/bin/remove_port_map
@@ -3,6 +3,10 @@ require 'port_map'
 
 name = ARGV[0] || Dir.pwd.split('/').last
 
+if File.exist?(PortMap::NginxConf::PORT_MAP_CONF_FILENAME)
+  name = PortMap::NginxConf.from_file('', File.new(PortMap::NginxConf::PORT_MAP_CONF_FILENAME)).name
+end
+
 port_map = PortMap::Mappings.all.detect do |element|
   element[:name] == name
 end


### PR DESCRIPTION
Fixes #1 

The remove_port_map didn't account for .port_map.conf server names. This was an issue as create_port_map did, which lead to some issues when using port_map.

The README was also updated to better explain the ordering.
